### PR TITLE
fix: graham-campbell/exceptions package version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.5.9",
         "laravel/framework": "~5.2",
-        "graham-campbell/exceptions": "^8.1",
+        "graham-campbell/exceptions": "~8.3",
         "doctrine/dbal": "~2.5",
         "guzzlehttp/guzzle": "~5.3|~6.0",
         "michelf/php-markdown": "~1.5"


### PR DESCRIPTION
8.7 is incompatible with L5.2

```
PHP Fatal error:  Uncaught exception 'ErrorException' with message 'Argument 1 passed to Illuminate\Foundation\Exceptions\Handler::__construct() must implement interface Illuminate\Contracts\Container\Container, instance of Illuminate\Log\Writer given, called in /Users/gpedro/pandaac/vendor/graham-campbell/exceptions/src/ExceptionHandler.php on line 63 and defined' in /Users/gpedro/pandaac/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php:44
Stack trace:
#0 /Users/gpedro/pandaac/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php(44): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(4096, 'Argument 1 pass...', '/Users/gpedro/p...', 44, Array)
#1 /Users/gpedro/pandaac/vendor/graham-campbell/exceptions/src/ExceptionHandler.php(63): Illuminate\Foundation\Exceptions\Handler->__construct(Object(Illuminate\Log\Writer))
#2 [internal function]: GrahamCampbell\Exceptions\ExceptionHandler->__construct(Object(Illuminate\Foundation\Application))
#3 /Users/gpedro/pandaac/vendor/lar in /Users/gpedro/pandaac/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php on line 44
PHP Fatal error:  Uncaught exception 'ErrorException' with message 'Argument 1 passed to Illuminate\Foundation\Exceptions\Handler::__construct() must implement interface Illuminate\Contracts\Container\Container, instance of Illuminate\Log\Writer given, called in /Users/gpedro/pandaac/vendor/graham-campbell/exceptions/src/ExceptionHandler.php on line 63 and defined' in /Users/gpedro/pandaac/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php:44
Stack trace:
#0 /Users/gpedro/pandaac/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php(44): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(4096, 'Argument 1 pass...', '/Users/gpedro/p...', 44, Array)
#1 /Users/gpedro/pandaac/vendor/graham-campbell/exceptions/src/ExceptionHandler.php(63): Illuminate\Foundation\Exceptions\Handler->__construct(Object(Illuminate\Log\Writer))
#2 [internal function]: GrahamCampbell\Exceptions\ExceptionHandler->__construct(Object(Illuminate\Foundation\Application))
#3 /Users/gpedro/pandaac/vendor/lar in /Users/gpedro/pandaac/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php on line 44
```
